### PR TITLE
Update .rubocop_base.yml

### DIFF
--- a/templates/.rubocop_base.yml
+++ b/templates/.rubocop_base.yml
@@ -34,6 +34,7 @@ AllCops:
   Include:
     - '**/Rakefile'
     - '**/config.ru'
+    - '**/Gemfile'
   Exclude:
     - 'bin/**/*'
     - 'script/**/*'


### PR DESCRIPTION
https://github.com/bbatsov/rubocop/issues/4300

We need to add the `Gemfile`, as the default `Include` array gets overridden by ours