### PR TITLE
Suggest to run db migrate to fix no schema.rb error

### DIFF
--- a/ruby_on_rails/app_initialisation.md
+++ b/ruby_on_rails/app_initialisation.md
@@ -67,7 +67,7 @@ end
 
 * Change also  `system!('bundle install')` to `system!('bundle install --jobs=3 --retry=3')`
 
-* check if `bin/setup` works properly
+* Run `bin/setup`. If it fails run `rails db:migrate`, then run `bin/setup` again. Now it should work.
 
 ## Configurations
 


### PR DESCRIPTION
when running bin/setup you get an error that there is no schema.rb. to fix this you have to run rails:db migrate. I updated the readme to explain this.