### PR TITLE
Change rails_helper template and correct the rspec guide

### DIFF
--- a/ruby_on_rails/rspec.md
+++ b/ruby_on_rails/rspec.md
@@ -45,7 +45,7 @@ Please check the [spec_helper template](../templates/spec/spec_helper.rb)
 
 * Inside `spec/rails_helper` we suggest to uncomment/enable the following:
 
-* before `require 'rspec/rails'`
+* At the top of the file
 
 ```ruby
 require 'simplecov'

--- a/ruby_on_rails/rspec.md
+++ b/ruby_on_rails/rspec.md
@@ -38,6 +38,7 @@ end
 end
 SimpleCov.minimum_coverage 100
 ```
+
 to run code coverage and exclude files with less then 5 lines of code.
 
 * Inside `spec/spec_helper` we suggest you to uncomment/enable the following:

--- a/ruby_on_rails/rspec.md
+++ b/ruby_on_rails/rspec.md
@@ -32,9 +32,9 @@ you should know exactly why you are adding each one of them, why is necessary
 ```ruby
 require 'simplecov'
 SimpleCov.start 'rails' do
-add_filter do |source_file|
-source_file.lines.count < 5
-end
+  add_filter do |source_file|
+    source_file.lines.count < 5
+  end
 end
 SimpleCov.minimum_coverage 100
 ```

--- a/ruby_on_rails/rspec.md
+++ b/ruby_on_rails/rspec.md
@@ -27,6 +27,19 @@ you should know exactly why you are adding each one of them, why is necessary
 
 * delete the `test` folder
 
+* At the top of the `spec/spec_helper`
+
+```ruby
+require 'simplecov'
+SimpleCov.start 'rails' do
+add_filter do |source_file|
+source_file.lines.count < 5
+end
+end
+SimpleCov.minimum_coverage 100
+```
+to run code coverage and exclude files with less then 5 lines of code.
+
 * Inside `spec/spec_helper` we suggest you to uncomment/enable the following:
 
 ```ruby
@@ -40,20 +53,6 @@ config.order = :random
 
 Kernel.srand config.seed
 ```
-
-* At the top of the `spec/spec_helper`
-
-```ruby
-require 'simplecov'
-SimpleCov.start 'rails' do
-add_filter do |source_file|
-source_file.lines.count < 5
-end
-end
-SimpleCov.minimum_coverage 100
-```
-
-to run code coverage and exclude files with less then 5 lines of code.
 
 Please check the [spec_helper template](../templates/spec/spec_helper.rb)
 

--- a/ruby_on_rails/rspec.md
+++ b/ruby_on_rails/rspec.md
@@ -41,23 +41,23 @@ config.order = :random
 Kernel.srand config.seed
 ```
 
-Please check the [spec_helper template](../templates/spec/spec_helper.rb)
-
-* Inside `spec/rails_helper` we suggest to uncomment/enable the following:
-
-* At the top of the file
+* At the top of the `spec/spec_helper`
 
 ```ruby
 require 'simplecov'
 SimpleCov.start 'rails' do
-  add_filter do |source_file|
-    source_file.lines.count < 5
-  end
+add_filter do |source_file|
+source_file.lines.count < 5
+end
 end
 SimpleCov.minimum_coverage 100
 ```
 
 to run code coverage and exclude files with less then 5 lines of code.
+
+Please check the [spec_helper template](../templates/spec/spec_helper.rb)
+
+* Inside `spec/rails_helper` we suggest to uncomment/enable the following:
 
 * after `require 'rspec/rails'`
 

--- a/templates/spec/rails_helper.rb
+++ b/templates/spec/rails_helper.rb
@@ -1,11 +1,3 @@
-require 'simplecov'
-SimpleCov.start 'rails' do
-    add_filter do |source_file|
-        source_file.lines.count < 5
-    end
-end
-SimpleCov.minimum_coverage 100
-
 ENV['RAILS_ENV'] ||= 'test'
 require 'spec_helper'
 require File.expand_path('../../config/environment', __FILE__)

--- a/templates/spec/rails_helper.rb
+++ b/templates/spec/rails_helper.rb
@@ -1,16 +1,14 @@
-ENV['RAILS_ENV'] ||= 'test'
-require 'spec_helper'
-require File.expand_path('../../config/environment', __FILE__)
-
 require 'simplecov'
 SimpleCov.start 'rails' do
-  add_filter do |source_file|
-    source_file.lines.count < 5
-  end
+    add_filter do |source_file|
+        source_file.lines.count < 5
+    end
 end
 SimpleCov.minimum_coverage 100
 
-
+ENV['RAILS_ENV'] ||= 'test'
+require 'spec_helper'
+require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 require 'capybara/rspec'
 require 'capybara/rails'

--- a/templates/spec/spec_helper.rb
+++ b/templates/spec/spec_helper.rb
@@ -1,3 +1,11 @@
+require 'simplecov'
+SimpleCov.start 'rails' do
+    add_filter do |source_file|
+        source_file.lines.count < 5
+    end
+end
+SimpleCov.minimum_coverage 100
+
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
 RSpec.configure do |config|


### PR DESCRIPTION
It may happen that SimpleCov doesn't recognise a class of the rails project when it has a name which is already used in an external gem (like 'Event'). 
In the SimpleCov guide they recommend that you should include SimpleCov at the top of the File (https://github.com/colszowka/simplecov#getting-started -> 2.), which solves this problem