### PR TITLE
Update .rubocop.yml

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -27,6 +27,9 @@ Naming/FileName:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+  
+Style/FormatStringToken:
+  Enabled: false  
 
 AllCops:
   TargetRailsVersion: 5.1


### PR DESCRIPTION
Disabled for two reasons:
1) It has many false positives including this (https://github.com/bbatsov/rubocop/issues/5223)
2) we don't use template strings