### PR TITLE
Update .rubocop.yml

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -28,6 +28,9 @@ Naming/FileName:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Rails/LexicallyScopedActionFilter:
+  Enabled: false  
+
 AllCops:
   TargetRailsVersion: 5.1
   TargetRubyVersion: 2.4


### PR DESCRIPTION
I completely disagree.

https://rubocop.readthedocs.io/en/latest/cops_rails/#railslexicallyscopedactionfilter

The actions are implicit in Rails controllers for a good reason: avoid to write unnecessary code and especially empty methods. This check wants me to fill my controller with empty methods.