### PR TITLE
Update sentry.md

### DIFF
--- a/ruby_on_rails/sentry.md
+++ b/ruby_on_rails/sentry.md
@@ -22,7 +22,7 @@ group :production do
 end
 ```
 
-* Add `SENTRY_DSN` and `SENTRY_PUBLIC_DSN` to `application.example.yml`
+* Add `SENTRY_DSN` to `application.example.yml`
 * Add `CSP_REPORT_URI` to `application.example.yml`
 * Enable CSP Reporting to Sentry in `config/initializers/content_security_policy.rb`:
 


### PR DESCRIPTION
https://docs.sentry.io/clients/javascript/config/
the `SENTRY_PUBLIC_DSN` is never used in this context