### PR TITLE
Fix for development

### DIFF
--- a/ruby_on_rails/sentry.md
+++ b/ruby_on_rails/sentry.md
@@ -25,11 +25,9 @@ end
 * Enable CSP Reporting to Sentry in `config/initializers/content_security_policy.rb`:
 
 ```ruby
-if Rails.env.production?
-  Rails.application.config.content_security_policy do |policy|
-    ...
-    policy.report_uri ENV['CSP_REPORT_URI']
-  end
+Rails.application.config.content_security_policy do |policy|
+  ...
+  policy.report_uri ENV['CSP_REPORT_URI'] if ENV['CSP_REPORT_URI']
 end
 ```
 


### PR DESCRIPTION
I would recommend to not set this for `development` since then we have to add an URI to the `application.yml`. Other option would be to check for presence. There i see the risk of missing it on production.