### PR TITLE
Enable frozen-literal-string

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -13,9 +13,6 @@ Metrics/LineLength:
 Style/Documentation:
   Enabled: false
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 Style/MixinUsage:
   Exclude:
   - 'bin/setup'


### PR DESCRIPTION
This rubocop check has been disabled one/two years ago.
I remember that I had a discussion if we should have enabled it or not.
I'd like to bring back this topic and discuss the possibility of re-introducing it.
The main reasons to have this comment are:
* it will be the default in ruby3 (be ready)
* improves performances and memory usage for free

Some refs:
* https://freelancing-gods.com/2017/07/27/friendly-frozen-string-literals.html
* https://stackoverflow.com/questions/37799296/what-does-the-comment-frozen-string-literal-true-do
* https://bugs.ruby-lang.org/issues/11473
