### PR TITLE
Disable RSpec/NestedGroups

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -36,7 +36,7 @@ RSpec/ExampleLength:
     - 'spec/requests/**/*'
 
 RSpec/NestedGroups:
-  Enabled: false
+  MaxNesting: 5
 
 AllCops:
   Exclude:

--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -38,6 +38,9 @@ RSpec/ExampleLength:
     - 'spec/system/**/*'
     - 'spec/requests/**/*'
 
+RSpec/NestedGroups:
+  Enabled: false
+
 AllCops:
   Exclude:
     - 'bin/**/*'


### PR DESCRIPTION
I do not see any advantage using this rule. IMO it does not lead to better code. i prefer rather to have more context but to be able to write well-structured specs.
https://www.rubydoc.info/gems/rubocop-rspec/1.7.0/RuboCop/Cop/RSpec/NestedGroups

I would avoid that writing test is to hard because of linters.