### PR TITLE
Update .rubocop.yml

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -34,7 +34,7 @@ RSpec/ExampleLength:
     - 'spec/requests/**/*'
 
 RSpec/NestedGroups:
-  MaxNesting: 5
+  Max: 5
 
 AllCops:
   Exclude:


### PR DESCRIPTION
Configuration key `MaxNesting` for RSpec/NestedGroups is deprecated in favor of `Max`. Please use that instead.