### PR TITLE
Replace 1-star gem

### DIFF
--- a/ruby_on_rails/rspec.md
+++ b/ruby_on_rails/rspec.md
@@ -13,7 +13,7 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'capybara-selenium'
+  gem 'selenium-webdriver'
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'shoulda-matchers'


### PR DESCRIPTION
I don't understand, how this could happen. `capybara-selenium` is a 1-star gem from 2014 which we introduced in August  2018.