### PR TITLE
Remove gems installed by default

### DIFF
--- a/ruby_on_rails/rspec.md
+++ b/ruby_on_rails/rspec.md
@@ -12,8 +12,6 @@ group :development, :test do
 end
 
 group :test do
-  gem 'capybara'
-  gem 'selenium-webdriver'
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'shoulda-matchers'


### PR DESCRIPTION
Related to #166. I double checked and these two gems are already present in a new Rails project.

See:

```sh
➜  ~ rails -v
Rails 5.2.2
➜  ~ rails new whats_in_gemfile
      create
      create  README.md
      create  Rakefile
     # ... suppressed
➜  ~ cat whats_in_gemfile/Gemfile
source 'https://rubygems.org'
git_source(:github) { |repo| "https://github.com/#{repo}.git" }
# ...
group :test do
  # Adds support for Capybara system testing and selenium driver
  gem 'capybara', '>= 2.15'
  gem 'selenium-webdriver'
  # Easy installation and use of chromedriver to run system tests with Chrome
  gem 'chromedriver-helper'
end
➜  ~    
```