### PR TITLE
Use Heroku app name

### DIFF
--- a/ruby_on_rails/newrelic.md
+++ b/ruby_on_rails/newrelic.md
@@ -16,5 +16,4 @@ NewRelic is a service to monitor app performance.
 
   ```yml
   NEW_RELIC_LICENSE_KEY: "from newrelic"
-  NEW_RELIC_APP_NAME: "[project-name]-[branch-name]"
   ```

--- a/ruby_on_rails/newrelic.md
+++ b/ruby_on_rails/newrelic.md
@@ -11,6 +11,7 @@ NewRelic is a service to monitor app performance.
   ```
 
 * Add a NewRelic configuration file [`config/newrelic.yml`](../templates/config/newrelic.yml) folder.
+  Adjust the app name for custom setups to something else than `HEROKU_APP_NAME`.
 
 * Add the new variables to your Heroku environments and `config/application.yml`:
 

--- a/templates/config/newrelic.yml
+++ b/templates/config/newrelic.yml
@@ -1,6 +1,6 @@
 production:
   license_key: <%= ENV['NEW_RELIC_LICENSE_KEY'] %>
-  app_name: <%= ENV['NEW_RELIC_APP_NAME'] %>
+  app_name: <%= ENV['HEROKU_APP_NAME'] %>
   monitor_mode: true
   developer_mode: false
   log_level: info


### PR DESCRIPTION
Since our fancy naming conventions, we can just use the Heroku app name. This will not work for custom setups, but well: they are custom.