### PR TITLE
Automatically delete head branches

### DIFF
--- a/configure_git_repository.md
+++ b/configure_git_repository.md
@@ -7,6 +7,7 @@ Please stick to it unless you have special needs.
   * Features: Remove *Wikis*, *Issues* and *Projects*
   * Data services: Enable *Dependency graph* and *Vulnerability alerts*
   * ~Merge button: Disable *Merge commits*~
+  * Merge button: Automatically delete head branches
 * Collaborators & teams
   * Add Renuo team as a collaborator with Admin access
   * Add Security team as collaborator with Write access


### PR DESCRIPTION
This feature is now available and deletes automatically the branch when the PR is merged. 
I'd enable it by default and also change this option in all our projects for the following reasons:
* I do not have to remember to delete it every time.
* you can always restore it.
* defaults matter!

![image](https://user-images.githubusercontent.com/1319150/64123878-d34f5380-cda5-11e9-82ba-833ee56dbe14.png)
