### PR TITLE
Use template token string format by default

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -26,6 +26,9 @@ Metrics/BlockLength:
   - 'spec/**/*.rb'
   - 'config/environments/**/*.rb'
 
+Style/FormatStringToken:
+  EnforcedStyle: template
+
 RSpec/MultipleExpectations:
   Enabled: false
 


### PR DESCRIPTION
```
# bad
format('%<greeting>s', greeting: 'Hello')
format('%s', 'Hello')

# good
format('%{greeting}', greeting: 'Hello')
```

The default in rubocop is the preferring `%<greeting>s`.