### PR TITLE
Avoid random failing tests

### DIFF
--- a/templates/spec/rails_helper.rb
+++ b/templates/spec/rails_helper.rb
@@ -28,6 +28,10 @@ RSpec.configure do |config|
     driven_by :selenium_chrome_headless
   end
 
+  config.after do
+    I18n.locale = I18n.default_locale
+  end
+
   config.after(:each, type: :system, js: true) do
     errors = page.driver.browser.manage.logs.get(:browser)
     if errors.present?


### PR DESCRIPTION
I fixed countless times random failing tests because this was missing. The last one was this morning. I'd like to have this as default.