### PR TITLE
Add a check for eager loading

### DIFF
--- a/ruby_on_rails/app_initialisation.md
+++ b/ruby_on_rails/app_initialisation.md
@@ -52,7 +52,7 @@ They are always idempotent (runnable multiple times).
 * Add a `bin/check` file. It will run all the automated tests. It's mainly used in our CI.
 
   ```sh
-  echo "#\!/bin/sh\nset -e\nbin/fastcheck\n" > bin/check
+  echo "#\!/bin/sh\nset -e\nbin/fastcheck\nbin/rails zeitwerk:check" > bin/check
   ```
 
 * Make the new scripts executable

--- a/templates/bin/check
+++ b/templates/bin/check
@@ -4,6 +4,8 @@ set -e
 
 bin/fastcheck
 
+bin/rails zeitwerk:check
+
 if ! grep --exclude-dir="app/assets/typings/**" -i -r 'console.log' app spec
 then
   echo 'console.log found. Please fix them and try again, commit aborted'


### PR DESCRIPTION
Zeitwer check can identify possible issues in production. 
This avoids having weird production issues where eager loading is enabled.