### PR TITLE
Add new rules

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -20,6 +20,15 @@ Style/MixinUsage:
 
 Style/NonNilCheck:
   IncludeSemanticChanges: true
+  
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
 
 Metrics/BlockLength:
   Exclude:


### PR DESCRIPTION
Rubocop will warn us for them:

```
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Style/HashEachMethods
 - Style/HashTransformKeys
 - Style/HashTransformValues
```

* https://docs.rubocop.org/en/stable/cops_style/#stylehashtransformkeys
* https://docs.rubocop.org/en/stable/cops_style/#stylehasheachmethods
* https://docs.rubocop.org/en/stable/cops_style/#stylehashtransformvalues

I think the rules are meaningful and should be enabled. We can add a note that we remove the rules again, once rubocop is on version `1.0.0`