### PR TITLE
Update .rubocop.yml

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -10,6 +10,15 @@ Rails/SkipsModelValidations:
 Layout/LineLength:
   Max: 120
 
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+  
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+  
 Style/Documentation:
   Enabled: false
 
@@ -28,6 +37,9 @@ Style/HashTransformKeys:
   Enabled: true
 
 Style/HashTransformValues:
+  Enabled: true
+  
+Style/ExponentialNotation:
   Enabled: true
 
 Metrics/BlockLength:


### PR DESCRIPTION
These cops are new in rubocop and should be configured. Otherwise you get warnings in `bin/check`

To discuss: 

We already had some new cops of this kind. In version 1.0 they are supposed to be default. Should we then remove them again? If so, should we group and mark them somehow?