### PR TITLE
Remove lograge from suggested libraries

### DIFF
--- a/suggested_libraries.md
+++ b/suggested_libraries.md
@@ -22,10 +22,6 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
 end
-
-group :production do
-  gem 'lograge'
-end
 ```
 
 ## :gem: Suggested NPM packages


### PR DESCRIPTION
We often find ourselves debugging production environments with scarce because of that. I'd suggest that we don't suggest it as a default. We can still add it for heavy load apps.