### PR TITLE
View spec exceptions

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -50,6 +50,10 @@ RSpec/ExampleLength:
     - 'spec/requests/**/*'
     - 'spec/views/**/*'
 
+RSpec/InstanceVariable:
+  Exclude:
+    - 'spec/views/**/*'
+
 RSpec/NestedGroups:
   Max: 5
 

--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -48,6 +48,7 @@ RSpec/ExampleLength:
   Exclude:
     - 'spec/system/**/*'
     - 'spec/requests/**/*'
+    - 'spec/views/**/*'
 
 RSpec/NestedGroups:
   Max: 5


### PR DESCRIPTION
The default Rails view specs already exceed the default Rubocop limits of 5, e.g.:

```ruby
  it 'renders the edit answer_option form' do
    render

    assert_select 'form[action=?][method=?]', answer_option_path(@answer_option), 'post' do
      assert_select 'textarea[name=?]', 'answer_option[text]'
      assert_select 'input[name=?]', 'answer_option[veridical]'
      assert_select 'input[name=?]', 'answer_option[question_id]'
    end
  end
```

Also: I think it's ok to use instance variables in views specs since this is the Rails way (not in partials though).