### PR TITLE
Reduce Heroku slug size

### DIFF
--- a/ruby_on_rails/app_initialisation.md
+++ b/ruby_on_rails/app_initialisation.md
@@ -122,6 +122,17 @@ create the initializer for figaro in `config/initializers/figaro.rb`:
 * Enable the default Content Security Policies in `config/initializers/content_security_policy.rb`.
   The report URI will be set later in the step of Sentry configuration.
 
+* If you're using Webpacker, let's clean up after asset precompilation
+  to reduce Heroku slug size. Add this to the `Rakefile`:
+
+  ```ruby
+  Rake::Task['assets:clean'].enhance do
+    FileUtils.remove_dir('node_modules', true)
+    FileUtils.remove_dir('vendor/javascript', true)
+    FileUtils.remove_dir('tmp/cache/webpacker', true)
+  end
+  ```
+
 ## Finalising
 
 * Check if the following scripts run successfully: `bin/setup`, `bin/check`, `bin/run`

--- a/ruby_on_rails/create_application_server.md
+++ b/ruby_on_rails/create_application_server.md
@@ -20,11 +20,21 @@ Pull Request on the [renuo-cli](https://github.com/renuo/renuo-cli) project.
 
 ## Setup Rails for Heroku
 
-Add a file called `Procfile` to your code root:
+* Add a file called `Procfile` to your code root:
 
-```
-web: bundle exec puma -C config/puma.rb
-release: bundle exec rails db:migrate
-```
+  ```
+  web: bundle exec puma -C config/puma.rb
+  release: bundle exec rails db:migrate
+  ```
 
-It's read by Heroku to start the web app and worker jobs.
+  It's read by Heroku to start the web app and worker jobs.
+
+* Add a file called `.slugignore` to your code root:
+
+  ```
+  /spec
+  /.semaphore
+  ```
+
+  Like this you can make files and folders to be excluded from the Heroku slug.
+


### PR DESCRIPTION
Webpacker produces 250mb JS files of no further use after asset compilation. Let's remove them.