### PR TITLE
Update .rubocop.yml

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -35,6 +35,12 @@ Metrics/BlockLength:
   - 'spec/**/*.rb'
   - 'config/environments/**/*.rb'
 
+Metrics/MethodLength:
+  CountAsOne:
+  - array
+  - hash
+  - heredoc
+
 RSpec/MultipleExpectations:
   Enabled: false
 


### PR DESCRIPTION
I update the Rubocop configuration to condense hashes, arrays and heredocs per default to one line (see https://github.com/rubocop-hq/rubocop/pull/8159).

The idea is to not make us work around the method length rules by squeezing to much onto one line, see the ticket https://github.com/rubocop-hq/rubocop/issues/7724 which I created.

Another example I just encountered:
```diff
-  def datepicker_options(start_date: 100.years.ago.to_date, end_date: Time.zone.today, required: false)
-    { as: :datepicker, required: required,
-      input_html: { type: :text,
-                    data: { date_start_date: (l start_date), date_end_date: (l end_date),
-                            date_start_view: 2, date_autoclose: true,
-                            date_language: I18n.locale[0..1],
-                            date_format: I18n.t('date.formats.datepicker'),
-                            provide: 'datepicker' } } }
-  end
+  def datepicker_options(start_date: 100.years.ago.to_date, end_date: Time.zone.today, required: false)
+    {
+      as: :datepicker,
+      required: required,
+      input_html: {
+        type: :text,
+        data: {
+          date_start_date: l(start_date),
+          date_end_date: l(end_date),
+          date_start_view: 'years',
+          date_autoclose: true,
+          date_language: I18n.locale[0..1],
+          date_format: I18n.t('date.formats.datepicker'),
+          provide: 'datepicker'
+        }
+      }
+    }
+  end
```

I clearly prefer the added option over the removed one (neglect the indentation but look at the line breaks).