### PR TITLE
Changing gem name from database-cleaner => database_cleaner

### DIFF
--- a/ruby_on_rails/cucumber.md
+++ b/ruby_on_rails/cucumber.md
@@ -14,7 +14,7 @@ To install `cucumber-rails`, add the following gems to your Gemfile:
 group :test do
     gem 'capybara', require: false
     gem 'cucumber-rails', require: false
-    gem 'database-cleaner'
+    gem 'database_cleaner'
 end
 ```
 


### PR DESCRIPTION
It seems like a typo has made its way into the repo 
Naming and Wiki:
https://github.com/DatabaseCleaner/database_cleaner