### PR TITLE
Add links to Rack [Cors , Attack]

### DIFF
--- a/ruby_on_rails/README.md
+++ b/ruby_on_rails/README.md
@@ -65,8 +65,8 @@ useful services:
 1. Rack Tracker (Google Analytics) `gem 'rack-tracker'` --> see [Google Analytics](../google_analytics.md)
 1. [Typescript](https://github.com/typescript-ruby/typescript-rails)
 1. Favicons
-1. [Rack CORS](../ruby_on_rails_api/rack_cors.md)
-1. [Rack Attack](../ruby_on_rails_api/rack_attack.md)
+1. [Rack CORS](https://github.com/cyu/rack-cors)
+1. [Rack Attack](https://github.com/rack/rack-attack#installing)
 1. [:fire: Hotjar](hotjar.md)
 1. SEO
     * redirect non-www to www


### PR DESCRIPTION
I'd propose to directly link the currently outdated links to their respective Github repos.
The both of them have well written READMEs.
Need be, a person can quickly get up to speed with the gem by reading their installation and configuration section. 

Resolving Issue #240