### PR TITLE
Enforce no_braces for the last element of the array

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -20,7 +20,7 @@ Style/MixinUsage:
 
 Style/NonNilCheck:
   IncludeSemanticChanges: true
-  
+
 Style/HashEachMethods:
   Enabled: true
 
@@ -29,6 +29,9 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+Style/HashAsLastArrayItem:
+  EnforcedStyle: no_braces
 
 Metrics/BlockLength:
   Exclude:


### PR DESCRIPTION
Please check https://docs.rubocop.org/rubocop/cops_style.html#stylehashaslastarrayitem
I use the "no_braces" rule, as the opposite of the default "braces" because it removes useless syntax.