### PR TITLE
Disable cop

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -20,7 +20,7 @@ Style/MixinUsage:
 
 Style/NonNilCheck:
   IncludeSemanticChanges: true
-  
+
 Style/HashEachMethods:
   Enabled: true
 
@@ -29,6 +29,9 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+Style/HashAsLastArrayItem:
+  Enabled: false
 
 Metrics/BlockLength:
   Exclude:


### PR DESCRIPTION
https://docs.rubocop.org/rubocop/cops_style.html#stylehashaslastarrayitem
I don't like to add syntax sugar if not needed. The "no_braces" option doesn't work well if you have an array of hashes. see #242 