### PR TITLE
Do not use syntax proposed by rubocop

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -7,6 +7,9 @@ Rails/SkipsModelValidations:
   Exclude:
     - 'spec/**/*.rb'
 
+Rails/WhereExists:
+  Enabled: false
+
 Layout/LineLength:
   Max: 120
 
@@ -20,7 +23,7 @@ Style/MixinUsage:
 
 Style/NonNilCheck:
   IncludeSemanticChanges: true
-  
+
 Style/HashEachMethods:
   Enabled: true
 


### PR DESCRIPTION
I disagree with https://docs.rubocop.org/rubocop-rails/2.7/cops_rails.html#railswhereexists

Rails already removed the possibility of putting conditions in methods like `all` to force people to define conditions in `where`. I'd even disable the possibility to pass conditions to `exists?`