### PR TITLE
Point to .semaphore folder

### DIFF
--- a/ruby_on_rails/configure_ci.md
+++ b/ruby_on_rails/configure_ci.md
@@ -25,7 +25,7 @@ The command will copy the templates to `.semaphore` folder.
 
 1. Create a folder called `.semaphore` in the project root with a file called `semaphore.yml` in it.
 
-1. Take the content of [this template](../templates/.semaphore/semaphore.yml) and replace [project-name] where
+1. Take the content of [this template](../templates/.semaphore) and replace [project-name] where
 needed.
 
     This runs a build and a testing process for your code.


### PR DESCRIPTION
Small improvement to get directly to all semaphore files, since the text talks about it in the context the 'template', not just the entry file