### PR TITLE
Change SparkPost instructions to use subaccounts

### DIFF
--- a/sparkpost.md
+++ b/sparkpost.md
@@ -1,31 +1,24 @@
 # SparkPost
 
+Each app is using a separate subaccount under the main SparkPost account sparkpost+renuoapp@renuo.ch.
+
+There are two paths when setting up the project on SparkPost:
+
+* The domain is known: it should be set up and verified under the subaccount's sending domains.
+* The domain is not known: the emails will be sent with **\*@renuoapp.ch** as your mail sender
+
 :warning:
-**Never ever set up a *\*.renuoapp.ch* as a sending domain to a new created account. This will block the account on SparkPost.
-If you need this, choose the second option.** :warning:
+Never use the primary account for the project, so that the whole account doesn't get suspended / blocked in case of compliance issues!
 
-There are two options to set up SparkPost:
+There should only be one SparkPost subaccount per project. This means, that *master*, *develop* and *testing* use the same one.
 
-* With a domain for the project and a separate SparkPost account (preferred, if possible)
-* Without an exisiting domain ==> via renuoapp.ch SparkPost account
-
-**Note:** With the second option, you are only able to send mails with **\*@renuoapp.ch** as your mail sender.
-
-## First Option
-
-There should only be one SparkPost account per project. This means, that *master*, *develop* and *testing* use the same one.
-
-1. Go to <https://app.sparkpost.com/sign-up/> and create a new account
-1. Use the email `sparkpost+[project-name]@renuo.ch` as your username
-1. Use `renuo generate-password` to generate a secure password
-1. Copy the credentials into the credential store
-1. Fill in the domain you plan to use
-1. Confirm your email address (sent to sparkpost@renuo.ch)
-   > Hint: <https://groups.google.com/a/renuo.ch/forum/#!topic/mandrill>
-1. Write down the API-key in the credential store, because it's only shown once!
-1. You can check your key under: <https://app.sparkpost.com/account/credentials>
-1. Validate your sending domain [here](https://app.sparkpost.com/account/sending-domains), or add it if not already done (Set up SPF & DKIM with TXT DNS records)
+1. Go to <https://app.sparkpost.com/auth> and log in with the credentials for
+   sparkpost+renuoapp@renuo.ch found in the credential store
+1. Create [one new subaccount](https://app.sparkpost.com/account/subaccounts) and name it like your project
+1. Create [a new API-Key for your subaccount](https://app.sparkpost.com/account/api-keys/create) and assign it to the new subaccount, with the following permissions: *Send via SMTP, Sending Domains: Read/Write*
+1. Write down the API-key in the credential store, because it's only showed once!
 1. Credentials for SMTP setup on your app can be found [here](https://app.sparkpost.com/account/smtp), password is your generated API-key
+1. (if domain is known) Add your sending domain [here](https://app.sparkpost.com/domains/create?type=sending). Assign it to the subaccount. Set up SPF & DKIM with TXT DNS records
 1. Set up your ENV-variables and test if the mails are working. Manual test emails can be send via the following command in the rails console (production environment): `ActionMailer::Base.mail(to: 'yourname@renuo.ch', subject: 'Testmail', body: 'Mail content').deliver_now!`
 
 For DNS setup also see [Go Live](go_live.md)
@@ -36,24 +29,12 @@ ENV-variables example:
 MAIL_USERNAME: 'SMTP_Injection'
 MAIL_PASSWORD:  'YOUR API KEY'
 MAIL_HOST: 'smtp.sparkpostmail.com'
-MAIL_SENDER: 'Sample App <sample-app@yourdomain.tld>'
-```
-
-## Second Option
-
-1. Go to <https://app.sparkpost.com/auth> and log in with the credentials found in the credential store
-1. Create [one new subaccount](https://app.sparkpost.com/account/subaccounts) and name it like your project
-1. Create [a new API-Key for your subaccount](https://app.sparkpost.com/account/credentials), with the following permissions: *Send via SMTP, Sending Domains: Read/Write*
-1. Write down the API-key in the credential store, because it's only showed once!
-1. Credentials for SMTP setup on your app can be found [here](https://app.sparkpost.com/account/smtp), password is your generated API-key
-1. Set up your ENV-variables and test if the mails are working. Manual test emails can be send via the following command in the rails console (production environment): `ActionMailer::Base.mail(to: 'yourname@renuo.ch', subject: 'Testmail', body: 'Mail content').deliver_now!`
-
-ENV-variables example:
-
-```
-MAIL_USERNAME: 'SMTP_Injection'
-MAIL_PASSWORD:  'YOUR API KEY'
-MAIL_HOST: 'smtp.sparkpostmail.com'
 MAIL_SENDER: 'Sample App <sample-app@renuoapp.ch>'
+```
+
+Or with a custom domain:
+
+```
+MAIL_SENDER: 'Sample App <sample-app@yourdomain.tld>'
 ```
 


### PR DESCRIPTION
After investigating the email providers situation, I think the subaccounts on Sparkpost are exactly what we need and we complicated our situation by setting up a completely new account for new projects.

![image](https://user-images.githubusercontent.com/3784696/106613080-177def00-656a-11eb-97c9-357982a46bb5.png)

Currently we have multiple projects that needed an upgrade to $20 plan, although they don't really utilise the plan. There's also quite a mess because of this, because some projects don't only have their own account, but are also set up under `sparkpost+renuoapp@renuo.ch` account.

By having them under one main account, we can have upgraded plan with (hopefully) better support on this account and covers all the subaccounts. Currently, there's 5 projects upgraded to a paid plan, but `renuoapp` is not one of them, so our customer support leverage is weaker.

Historically, I think the main reason to split the accounts was that there was 100 000 emails in the free plan, which is not the case anymore. 
 
Or can you recall if there was any other reason / problem with the subaccounts that I'm not aware of?

If this sounds good to you, I'd propose to migrate all the paying customers as subaccounts of the `renuoapp` account, which we upgrade.
Hopefully, this will not cause a lot of headaches with the sending domains, because they need to be detached from one account and verified in the new one.