### PR TITLE
Update rubocop.yml

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -47,6 +47,12 @@ Metrics/MethodLength:
   - array
   - hash
   - heredoc
+  
+Metrics/ClassLength:
+  CountAsOne:
+  - array
+  - hash
+  - heredoc  
 
 RSpec/MultipleExpectations:
   Enabled: false


### PR DESCRIPTION
Since it counts as one for the method it should count as one also for the class. I don't want to be bother by the "class-level" check if the "method-level" one does not complain