### PR TITLE
add rubocop to db folder

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -18,8 +18,8 @@ Style/Documentation:
 
 Style/MixinUsage:
   Exclude:
-  - 'bin/setup'
-  - 'bin/update'
+    - 'bin/setup'
+    - 'bin/update'
 
 Style/NonNilCheck:
   IncludeSemanticChanges: true
@@ -38,21 +38,32 @@ Style/HashAsLastArrayItem:
 
 Metrics/BlockLength:
   Exclude:
-  - 'spec/**/*.rb'
-  - 'config/environments/**/*.rb'
-  - 'config/routes.rb'
+    - 'spec/**/*.rb'
+    - 'config/environments/**/*.rb'
+    - 'config/routes.rb'
+    - 'db/**/*'
+
+Metrics/AbcSize:
+  Exclude:
+    - 'db/migrate/*'
+
+Rails/NotNullColumn:
+  Exclude:
+    - 'db/migrate/*'
 
 Metrics/MethodLength:
   CountAsOne:
-  - array
-  - hash
-  - heredoc
+    - array
+    - hash
+    - heredoc
   
 Metrics/ClassLength:
   CountAsOne:
-  - array
-  - hash
-  - heredoc  
+    - array
+    - hash
+    - heredoc
+  Exclude:
+    - 'db/**/*'
 
 RSpec/MultipleExpectations:
   Enabled: false
@@ -86,6 +97,6 @@ AllCops:
     - 'log/**/*'
     - 'public/**/*'
     - 'tmp/**/*'
-    - 'db/**/*'
+    - 'db/schema.rb'
     - 'vendor/**/*'
     - 'node_modules/**/*'


### PR DESCRIPTION
I think its important to also have some linters in the migrations. We introduced linters to migration on https://github.com/renuo/loyalty and Edge and I liked it. Since it can still detect some in-reversible migrations or code smells