### PR TITLE
Disable MultipleMemoizedHelpers Cop

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -89,6 +89,9 @@ RSpec/InstanceVariable:
 RSpec/NestedGroups:
   Max: 5
 
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
 AllCops:
   NewCops: enable
   Exclude:


### PR DESCRIPTION
[rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleMemoizedHelpers
](https://rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleMemoizedHelpers
)
The cop would check if example groups contain too many `let` and `subject` calls. As discussed with @coorasse this does not lead to better design in our opinion. People would change the amount of allowed let-statements or trick and use instance variables in `before`, if they need more. so i’d rather like to disable it.