### PR TITLE
Add pry-doc as suggested

### DIFF
--- a/suggested_libraries.md
+++ b/suggested_libraries.md
@@ -21,6 +21,7 @@ end
 group :development, :test do
   gem 'bullet'
   gem 'pry-byebug'
+  gem 'pry-doc'
   gem 'pry-rails'
 end
 


### PR DESCRIPTION
Makes Ruby docs accessible in pry.

Got the idea from here: https://www.shakacode.com/blog/railsconf-2021-implicit-to-explicit-decoding-rubys-magical-syntax/