### PR TITLE
Disable Naming/InclusiveLanguage

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -65,6 +65,9 @@ Metrics/ClassLength:
   Exclude:
     - 'db/**/*'
 
+Naming/InclusiveLanguage:
+  Enabled: false
+
 RSpec/MultipleExpectations:
   Enabled: false
 


### PR DESCRIPTION
I don't agree with forcing human language into cultural limits and therefore propose to disable the cop introduced by https://github.com/rubocop/rubocop/pull/9842.

My code normally offends people in a lot of different non-cultural ways already. It's fine if Rubocop complains about those.
But **please talk to me in person** if my code offends you by cultural issues.