### PR TITLE
Add git flag

### DIFF
--- a/templates/bin/fastcheck
+++ b/templates/bin/fastcheck
@@ -11,7 +11,7 @@ then
 fi
 
 bundle exec brakeman -q -z --no-summary --no-pager
-bundle exec mdl ./
+bundle exec mdl ./ -g
 
 # old SCSS linter (deprecated)
 bundle exec scss-lint `find app/assets/stylesheets/ -name "*.scss"`


### PR DESCRIPTION
markdownlint would try to lint files inside `node_modules`. The `-g` flag allows just the linting of files known to git.

![Screenshot 2022-01-06 at 14 24 13](https://user-images.githubusercontent.com/50821376/148389474-e37737b6-9375-4564-8952-ede8f53cdefc.png)
