### PR TITLE
Add hint to environment in report uri

### DIFF
--- a/ruby_on_rails/sentry.md
+++ b/ruby_on_rails/sentry.md
@@ -39,7 +39,7 @@ You can use `renuo configure-sentry project-name <SENTRY_DSN>` to generate the c
   end
   ```
 
-  You can find the correct value in `Sentry -> Project Settings -> Security Headers -> REPORT URI`. Add the environment to the `CSP_REPORT_URI` using `&sentry_environment=master`.
+  You can find the correct value in `Sentry -> Project Settings -> Security Headers -> REPORT URI`. Add the environment to the `CSP_REPORT_URI` using `&sentry_environment=main`.
 
 ## Frontend (Javascript)
 

--- a/ruby_on_rails/sentry.md
+++ b/ruby_on_rails/sentry.md
@@ -39,7 +39,7 @@ You can use `renuo configure-sentry project-name <SENTRY_DSN>` to generate the c
   end
   ```
 
-  You can find the correct value in `Sentry -> Project Settings -> Security Headers -> REPORT URI`.
+  You can find the correct value in `Sentry -> Project Settings -> Security Headers -> REPORT URI`. Add the environment to the `CSP_REPORT_URI` using `&sentry_environment=master`.
 
 ## Frontend (Javascript)
 


### PR DESCRIPTION
https://redmine.renuo.ch/issues/17665

CSP issues in sentry (e.g. https://sentry.io/organizations/renuo/issues/3083804386/?project=212485) do not have the correct environment and therefore do not show up in the dashboard correctly. It's not a major issue but for future project it would be nice to have this. I'd not go through the old projects but fix them if they show up in the wrong place.

https://docs.sentry.io/product/security-policy-reporting/