### PR TITLE
Enforce ~consistent~ either hash syntax

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -27,6 +27,10 @@ Style/NonNilCheck:
 Style/HashEachMethods:
   Enabled: true
 
+Style/HashSyntax:
+  Enabled: true
+  EnforcedShorthandSyntax: consistent
+
 Style/HashTransformKeys:
   Enabled: true
 

--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -29,7 +29,7 @@ Style/HashEachMethods:
 
 Style/HashSyntax:
   Enabled: true
-  EnforcedShorthandSyntax: consistent
+  EnforcedShorthandSyntax: either
 
 Style/HashTransformKeys:
   Enabled: true


### PR DESCRIPTION
`EnforcedShorthandSyntax: always` is the default setting in Rubocop even though Bozhidar himself [doesn't like the option](https://batsov.com/articles/2022/01/20/bad-ruby-hash-value-omission/). 

~I suggest to change the default option to `consistent` because I can see the advantage of the shorthand syntax when passing on options to deeper levels. But in any other context I found myself to be confused by it.~

~This change allows hashes to be in shorthand syntax only if the whole hash uses it consistently. See https://github.com/rubocop/rubocop/pull/10776.~

**Update:**
I changed my mind. Let's follow standardrb. Be consistent yourselves if you see fit.