### PR TITLE
Disable RSpec/NoExpectationExample

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -105,6 +105,9 @@ RSpec/NestedGroups:
 
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
+  
+RSpec/NoExpectationExample:  
+  Enabled: false
 
 AllCops:
   NewCops: enable


### PR DESCRIPTION
Too many false positives. We use custom expectations very often and the risk of having a test without an expectation is low: https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecnoexpectationexample

This cop simply goes too far.