### PR TITLE
Disable RSpec/SortMetadata check

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -109,6 +109,9 @@ RSpec/MultipleMemoizedHelpers:
 RSpec/NoExpectationExample:  
   Enabled: false
 
+RSpec/SortMetadata:
+  Enabled: false
+
 AllCops:
   NewCops: enable
   Exclude:


### PR DESCRIPTION
The current order of the specified metadata makes more sense by putting the common options first and the special ones last. Sorting them alphabetically makes it less readable.