### PR TITLE
Disable RSpec/AnyInstance

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -111,6 +111,9 @@ RSpec/NoExpectationExample:
 
 RSpec/SortMetadata:
   Enabled: false
+  
+RSpec/AnyInstance:
+  Enabled: false
 
 AllCops:
   NewCops: enable


### PR DESCRIPTION
I am really annoyed by this cop. If I am using `allow_any_instance` is because I want to use it and doing it differently is just painful.