### PR TITLE
Disable Bundler/OrderedGems

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -3,6 +3,9 @@ require:
   - rubocop-rails
   - rubocop-rspec
 
+Bundler/OrderedGems:
+  Enabled: false
+
 Rails/SkipsModelValidations:
   Exclude:
     - 'spec/**/*.rb'


### PR DESCRIPTION
Because why do you care? If you want to check if a gem is configured you look at Gemfile.lock anyway