### PR TITLE
Remove trailing whitespace in ruby template file

### DIFF
--- a/templates/spec/support/javascript_error_reporter.rb
+++ b/templates/spec/support/javascript_error_reporter.rb
@@ -1,4 +1,4 @@
-module JavaScriptErrorReporter 
+module JavaScriptErrorReporter
   RSpec.configure do |config|
     config.after(:each, type: :system, js: true) do
       errors = page.driver.browser.logs.get(:browser)
@@ -8,9 +8,9 @@ module JavaScriptErrorReporter
           expect(error.level).not_to eq('SEVERE'), error.message
 
           next unless error.level == 'WARNING'
-          warn "\e[33m\nJAVASCRIPT WARNING\n#{error.message}\e[0m" 
+          warn "\e[33m\nJAVASCRIPT WARNING\n#{error.message}\e[0m"
         end
       end
-    end  
+    end
   end
 end


### PR DESCRIPTION
rubocop will complain about that otherwise.