### PR TITLE
Disable buggy ActionControllerFlashBeforeRender cop

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -68,6 +68,9 @@ Rails/I18nLocaleAssignment:
   Exclude:
     - 'spec/**/*'
 
+Rails/ActionControllerFlashBeforeRender:
+  Enabled: false
+
 Metrics/MethodLength:
   CountAsOne:
     - array


### PR DESCRIPTION
This cop seems to have quite a lot false positives pop up every now and then which are actually harmful since we won't render the flash in these cases.

See https://github.com/rubocop/rubocop-rails/issues/843 and https://github.com/renuo/vdrb-kas/pull/236/commits/7978dd7518f22fcef6768fe8fceed9f56377cddf