### PR TITLE
changes following voice-ai app setup

### DIFF
--- a/ruby_on_rails/app_initialisation.md
+++ b/ruby_on_rails/app_initialisation.md
@@ -70,10 +70,12 @@ They are always idempotent (runnable multiple times).
 ### ENV variables with Figaro
 
 * Add `figaro` to Gemfile. Check the [gem homepage](https://github.com/laserlemon/figaro) to see how to install the gem
-(usually `bundle exec figaro install` is enough). Delete the newly created file `config/application.yml`.
+(usually `bundle exec figaro install` is enough). Delete the newly created file `config/application.yml`...
 * and create `config/application.example.yml` where you will specify the only environment variable you need for now:
   `SECRET_KEY_BASE`.
-* Add the following section to your `bin/setup` script so that the application.yml is created when the project is setup:
+* Going forward we will only push the `config/application.example.yml` file to the repository in order to protect our env variables.
+* Add application.yml to .gitignore
+* Add the following section to your `bin/setup` script so that the `application.yml` is created from the `application.example.yml` when the project is setup locally:
 
   ```ruby
   puts "\n== Copying sample files =="
@@ -82,8 +84,8 @@ They are always idempotent (runnable multiple times).
   end
   ```
 
-* add application.yml to .gitignore
-* add one first key to application.example.yml `APP_PORT: 3000`
+
+* add one more key to application.example.yml `APP_PORT: 3000`
 
   Make sure it comes **before** any `rails` comands.
 * To ensure you have all the required keys from the `application.example.yml` in your `application.yml`,

--- a/ruby_on_rails/app_initialisation.md
+++ b/ruby_on_rails/app_initialisation.md
@@ -84,7 +84,6 @@ They are always idempotent (runnable multiple times).
   end
   ```
 
-
 * add one more key to application.example.yml `APP_PORT: 3000`
 
   Make sure it comes **before** any `rails` comands.

--- a/ruby_on_rails/aws.md
+++ b/ruby_on_rails/aws.md
@@ -39,6 +39,8 @@ aws configure --profile renuo-app-setup
 
 If you want to check your config, run `aws configure --profile renuo-app-setup list`.
 
+We would recommend setting default region name to `eu-central-1`. The default output format is json and should not be changed.
+
 ### Command generation
 
 The following command will generate command-line-commands to set up S3 and CloudFront.
@@ -63,6 +65,8 @@ You'll need to run them by yourself after reviewing the output.
 
 Running the commands will print some JSON pages to your screen.
 **Copy each `SecretAccessKey` and `AccessKeyId` to your credentials store!**
+
+Once you have worked through the commands, you are ready to use S3 for Active Storage within your Rails app by configuring the storage.yml file (as below) and setting `config.active_storage.service = :amazon` in your production.rb file.
 
 ### Custom Cloudfront Distribution CNAME Aliases
 

--- a/ruby_on_rails/configure_ci.md
+++ b/ruby_on_rails/configure_ci.md
@@ -17,7 +17,7 @@ and the main branches already pushed and ready to be tested.
 renuo configure-semaphore
 ```
 
-The command will copy the necessary templates to `.semaphore` folder.
+The command will copy the necessary templates to `.semaphore` folder using the renuo-cli. These files need to be maintained on the [renuo-cli repository](https://github.com/renuo/renuo-cli/tree/main).
 
 1. Add a file called `.nvmrc` to the project root, where you specify the latest node version
 1. Commit the files to both branches, push and watch the CI run.

--- a/ruby_on_rails/linting_and_automatic_check.md
+++ b/ruby_on_rails/linting_and_automatic_check.md
@@ -55,6 +55,8 @@ To lint the SASS/SCSS files in our project we are going to use the `sass-lint` n
 Add to the project the linter configuration file you can find in the templates folder and check the `bin/fastcheck`
 template to see the command to execute the SCSS linting.
 
+You may also need to add the `scss_lint` gem to your gemfile.
+
 ## Erb lint
 
 ```ruby

--- a/ruby_on_rails/suggested_libraries.md
+++ b/ruby_on_rails/suggested_libraries.md
@@ -29,6 +29,7 @@ group :production do
   gem 'lograge'
 end
 ```
+Note that to install `simple_form` you need to run `rails generate simple_form:install --bootstrap` (without option if not using Bootstrap) after adding it to your Gemfile.
 
 ## :gem: Suggested NPM packages
 


### PR DESCRIPTION
Just some minor changes after working through the guide when setting up Voice AI - this app was a little different though as we tried to deploy with mrsk instead of Heroku.

Key changes:
- Added more explanation on Figaro gem
- I needed to add scss_lint gem - not sure if always required
- Note that additional rails command needed for simple_form
- Added some instruction for setting up Amazon S3

Still to do: the renuo-cli semaphore command creates files with the deprecated `--cache-folder` option. I'm happy to create a PR if agreed that changes needed.