### PR TITLE
Add hint for all-cops extension

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -1,2 +1,10 @@
 inherit_gem:
   renuocop: config/base.yml
+
+# most likely you would like to copy and adjust the `AllCops` part (e.g. to exclude vendor-files)
+# AllCops:
+#   NewCops: enable
+#   Exclude:
+#     - 'vendor/**/*'
+#     ... and add all the exclusions from the `config/base.yml`
+


### PR DESCRIPTION
Background:

- as for the new interns i saw that it lead to confusion that rubocop modified gem-files when running bin/fastcheck

I had a quick discussion with @coorasse wether to add this extension to renuocop or here in the setup guide. i made a short pro/con for renuocop:

* pro:
  - it's a good default (and vendor is atm missing - so it's likely that you also miss this out)
  - there is already rails-specific stuff in the renuocop
  - if i add it to ASG there is possible divergence between asg and rubocop (since exclusions are not deep merged)

* con:
  - you will modify the all-cop anyways most likely to the needs of your project and thus copy it
 

Discussion is open :-)  maybe we could also work with extend in yml files?
