### PR TITLE
Use bash from env for better portability

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 set -euo pipefail
 

--- a/bin/setup
+++ b/bin/setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
Hi
According to [Stackoverflow](https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang#10383546) it looks like the portability of the scripts could be improved by having this new style for the bash shebang.