### PR TITLE
Add info on how to fix severity on appsignal

### DIFF
--- a/ruby_on_rails/appsignal.md
+++ b/ruby_on_rails/appsignal.md
@@ -36,7 +36,7 @@ Then add this log drain using the heroku commands displayed.
 
 ## Correct Severity
 
-According to the docs, getting the severity to be anything but "INFO" is not possible using the heroku drain.
+According to [the docs](https://docs.appsignal.com/logging/platforms/heroku.html), getting the severity to be anything but "INFO" is not possible using the heroku drain.
 
 However, there is now a way to send the `"severity=XYZ"` logfmt information and have that be applied correctly in appsignal. Unfortunately, just setting this seems to break the recognition of `request_id` in the format `[1234-5678]`. So we have to override the `ActiveSupport::TaggedLogging::Formatter` to add both the `severity` and the `request_id` in logfmt syntax.
 
@@ -68,6 +68,7 @@ and
 ```
 # config/environments/production.rb
 Rails.application.configure do
+  # We use our custom key value tagging
   config.log_tags = [lambda { |request| {request_id: request.request_id} }]
   logger           = ActiveSupport::Logger.new(STDOUT)
   config.logger    = ActiveSupport::TaggedLogging.new(logger)


### PR DESCRIPTION
This came after quite some testing by @rnestler and me.

The reason we require such a heavy solution is that we need to display two custom pieces of information (`severity` and `request_id`) and we need to display both of them in `logfmt` format.

Rails comes with `ActiveSupport::TaggedLogging` which gets information about the `request_id` injected by rack middleware. That info then gets passed to the formatter. Unfortunately it is limited displaying tags in the `[TAG]` format. We could re-implement all of `ActiveSupport::TaggedLogging` and the `ActiveSupport::TaggedLogging::Formatter` to do the same thing but format it as `logfmt`. However, since there will never be both of them active at the same time, overriding it seems like the better solution.

This information is global to the request. The severity on the other hand can differ from each call to the logger so it can't just be set as a tag.