### PR TITLE
rails: Use ENV.fetch instead of ENV[] || default

### DIFF
--- a/ruby_on_rails/app_initialisation.md
+++ b/ruby_on_rails/app_initialisation.md
@@ -109,7 +109,7 @@ create the initializer for figaro in `config/initializers/figaro.rb`:
 
   ```ruby
   config.force_ssl = true # uncomment
-  config.log_level = ENV['RAILS_LOG_LEVEL']&.to_sym || :warn # change
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "warn") # change
   ```
 
 * Update `config/environments/development.rb` settings:


### PR DESCRIPTION
When generating a new project with Rails 7.1 it uses `ENV.fetch("RAILS_LOG_LEVEL", "info")`, so we can just change the string to `"warn"` there.