### PR TITLE
fix appsignal logtags config template

### DIFF
--- a/ruby_on_rails/appsignal.md
+++ b/ruby_on_rails/appsignal.md
@@ -54,7 +54,7 @@ module ActiveSupport
           if tag.is_a? Hash
             text += tag.map { |k,v| "#{k}=#{v} " }.join
           else
-            raise 'we use our own tags!'
+            text += "[#{tag}] "
           end
         end
       end


### PR DESCRIPTION
The idea behind this was for us to notice if something overrides or appends to `config.log_tags` with the default (not key-value) format.

Unfortunately, `config.log_tags` is not used by ActiveJob/Sidekiq so we still need to handle the standard tags.