### PR TITLE
Update CI config guide

### DIFF
--- a/ruby_on_rails/configure_ci.md
+++ b/ruby_on_rails/configure_ci.md
@@ -10,6 +10,7 @@ and the main branches already pushed and ready to be tested.
 1. Proceed to <https://renuo.semaphoreci.com/> and login through GitHub with renuobot@renuo.ch ([1Password](https://start.1password.com/open/i?a=QZNJJCCDWVCGBGI73Z2L55KSGE&v=crlutt26yprmp6thr573qxsxkq&i=u7rirvnrf5fjxd25caiq7ib6vq&h=renuo.1password.com))
 1. Follow these instructions to install semaphore CLI https://docs.semaphoreci.com/reference/sem-command-line-tool/
 1. Create a project here: <https://renuo.semaphoreci.com/new_project>
+1. Set the [artifact retention policies](https://docs.semaphoreci.com/essentials/artifacts/#artifact-retention-policies) to 2 weeks: `Projects` > `[Name]` > `Settings` > `Artifacts`
 
 ## Rails specific configuration
 


### PR DESCRIPTION
the `--expire-in` flag is deprecated, therefore we have to edit it manually on semaphore