### PR TITLE
Remove `bin/fastcheck` from `bin/check` script

### DIFF
--- a/ruby_on_rails/app_initialisation.md
+++ b/ruby_on_rails/app_initialisation.md
@@ -58,7 +58,7 @@ They are always idempotent (runnable multiple times).
 * Add a `bin/check` file. It will run all the automated tests. It's mainly used in our CI.
 
   ```sh
-  echo "#\!/usr/bin/env bash\nset -euo pipefail\nbin/fastcheck\nbin/rails zeitwerk:check" > bin/check
+  echo "#\!/usr/bin/env bash\n\nset -euo pipefail\n\nbin/rails zeitwerk:check" > bin/check
   ```
 
 * Make the new scripts executable

--- a/templates/bin/check
+++ b/templates/bin/check
@@ -2,8 +2,6 @@
 
 set -e
 
-bin/fastcheck
-
 bin/rails zeitwerk:check
 
 if ! grep --exclude-dir="app/assets/typings/**" -i -r 'console.log' app spec


### PR DESCRIPTION
Executing `bin/fastcheck` in `bin/check` causes it to be executed twice on the CI and thus increasing CI time. In some projects, this was already removed. We should do the same for all other projects as well to keep it consistent and fast

