### PR TITLE
Add rails_helper I18n locale reset configuration

### DIFF
--- a/ruby_on_rails/rspec.md
+++ b/ruby_on_rails/rspec.md
@@ -94,6 +94,12 @@ You should know exactly why you are adding each one of them and why is necessary
       config.before(:each, type: :system, js: true) do
         driven_by ENV['SELENIUM_DRIVER']&.to_sym || :selenium_chrome_headless
       end
+
+      config.around do |example|
+        locale_before = I18n.locale
+        example.call
+        raise "This test did not reset the locale properly" if I18n.locale != locale_before
+      end
     end
 
   # config/application.example.yml

--- a/ruby_on_rails/rspec.md
+++ b/ruby_on_rails/rspec.md
@@ -95,10 +95,8 @@ You should know exactly why you are adding each one of them and why is necessary
         driven_by ENV['SELENIUM_DRIVER']&.to_sym || :selenium_chrome_headless
       end
 
-      config.around do |example|
-        locale_before = I18n.locale
-        example.call
-        raise "This test did not reset the locale properly" if I18n.locale != locale_before
+      config.before do |example|
+        I18n.locale = I18n.default_locale
       end
     end
 


### PR DESCRIPTION
Does it make sense to move the rspec configuration inside of the I18n templates instead of having it in the rspec section?
https://github.com/renuo/applications-setup-guide/blob/main/i18n.md