### PR TITLE
Add explicit hint to update plugin libraries

### DIFF
--- a/ruby_on_rails/app_initialisation.md
+++ b/ruby_on_rails/app_initialisation.md
@@ -2,7 +2,7 @@
 
 ## Default Rails setup
 
-* Ensure that your asdf plugins are up to date with `asdf plugin update -all`.
+* Ensure that your asdf plugins are up to date with `asdf plugin update --all`.
 
 * Install the latest Ruby version with `asdf install ruby latest` (Check if it's supported by Heroku).
 

--- a/ruby_on_rails/app_initialisation.md
+++ b/ruby_on_rails/app_initialisation.md
@@ -2,9 +2,11 @@
 
 ## Default Rails setup
 
+* Ensure that your asdf plugins are up to date with `asdf plugin update -all`.
+
 * Install the latest Ruby version with `asdf install ruby latest` (Check if it's supported by Heroku).
 
-* Switch your global Ruby to the fresh one: `asdf global ruby latest`
+* Switch your global Ruby to the fresh one: `asdf global ruby latest`.
 
 * Run `gem update --system` to update Ruby's default gems (e.g. `bundler`).
 


### PR DESCRIPTION
Since the ASG recommends installing ruby with asdf (and I don't know of a way to tell asdf to automatically update its libraries periodically), I think it's worth having a small hint to update them manually before installing the latest ruby version. That way one can be sure they're really getting the latest version.