### PR TITLE
Disable default preprocessors

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -7,6 +7,7 @@ title = "Renuo - Application Setup Guide"
 
 [build]
 create-missing = false
+use-default-preprocessors = false
 
 [output.html.search]
 limit-results = 10


### PR DESCRIPTION
Relative links to README.md seem problematic in mdBook, and there is no proper solution other than disabling default preprocessors.

[Issue that describes this behavior](https://github.com/rust-lang/mdBook/issues/1920)
[Pull Request to fix the issue](https://github.com/rust-lang/mdBook/pull/1921)

> The following preprocessors are built-in and included by default:
> 
>   links: Expands the {{ #playground }}, {{ #include }}, and {{ #rustdoc_include }} handlebars helpers in a chapter to include the contents of a file. See [Including files](https://rust-lang.github.io/mdBook/format/mdbook.html#including-files) for more.
>   index: Convert all chapter files named README.md into index.md. That is to say, all README.md would be rendered to an index file index.html in the rendered book.

https://rust-lang.github.io/mdBook/format/configuration/preprocessors.html#configuring-preprocessors

The relative links have been tested to work locally.
