### PR TITLE
Update naming conventions

### DIFF
--- a/naming_conventions.md
+++ b/naming_conventions.md
@@ -15,7 +15,7 @@ asked to do the same.
 
 * Use `[project-name]` for project names and services which are branch-independent.
 * Use `[project-name]-[branch]` for deployed projects (`[branch]` means the gitflow branch and not RAILS_ENV).
-* Use `[project-name]-[branch]-[purpose]` for deployed projects (e.g. kingschair-main-assets).
+* Use `[project-name]-[purpose]-[branch]` for deployed projects (e.g. one11-web-main).
 * Use `[project-name]-local-[user]-[rails_env]` for local names which interact with online services (e.g. S3).
 
 ## Examples

--- a/naming_conventions.md
+++ b/naming_conventions.md
@@ -18,6 +18,8 @@ asked to do the same.
 * Use `[project-name]-[purpose]-[branch]` for deployed projects (e.g. one11-web-main).
 * Use `[project-name]-local-[user]-[rails_env]` for local names which interact with online services (e.g. S3).
 
+**Note:** Previously on Heroku, the convention was to use `[project-name]-[branch]-[purpose]` for deployed projects (e.g. kingschair-main-assets). This has been updated due to deplo.io.
+
 ## Examples
 
 * food-calendar, food-calendar-develop, food-calendar-develop-assets


### PR DESCRIPTION
With the ongoing migrations from Heroku to Deploio, it is time to rethink the naming conventions of our current and future projects as the existing conventions are not transferable to Deploio.

## Heroku:

**Simple projects:**

* Organization: renuo
* Project: [REPOSITORY_NAME]
* App: [REPOSITORY_NAME]-[BRANCH] 

**Monorepos / Microservices:**

* Organization: renuo
* Project: [REPOSITORY_NAME]
* App: [REPOSITORY_NAME]-[USAGE]-[BRANCH]

## Deploio

**Simple projects:**

* Organization: renuo
* Project: [REPOSITORY_NAME]
* App: [BRANCH] 

Full name: renuo-[REPOSITORY_NAME]-[BRANCH]
Example name: renuo-renuo-website-v3-main

**Monorepos / Microservices:**

* Organization: renuo
* Project: [REPOSITORY_NAME]-[USAGE]
* App: [BRANCH]

Full name: renuo-[REPOSITORY_NAME]-[USAGE]-[BRANCH]
Example name: renuo-one11-web-develop
