### PR TITLE
Link supported ruby versions

### DIFF
--- a/ruby_on_rails/app_initialisation.md
+++ b/ruby_on_rails/app_initialisation.md
@@ -44,7 +44,7 @@ Some other adjustments must be performed manually.
 ### Automatic adjustments
 
 > ⭐The Gemfile reads the required ruby version from the `.ruby-version` file.
-> [This is used by Heroku to determine what version to use.](https://devcenter.heroku.com/articles/ruby-versions)
+> [This is used by Heroku and Deploio to determine what version to use.](https://devcenter.heroku.com/articles/ruby-versions)
 
 > ⭐️renuocop replaces the default rubocop-rails-omakase. We have our own set of rules at Renuo.
 > You can discuss them at https://github.com/renuo/renuocop and you can also contribute to them.

--- a/ruby_on_rails/app_initialisation.md
+++ b/ruby_on_rails/app_initialisation.md
@@ -4,7 +4,7 @@
 
 * Ensure that your asdf plugins are up to date with `asdf plugin update --all`.
 
-* Install the latest Ruby version with `asdf install ruby latest` (Check if it's supported by Heroku).
+* Install the latest Ruby version with `asdf install ruby latest` (Check if it's [supported by Heroku](https://devcenter.heroku.com/articles/ruby-support#ruby-versions)).
 
 * Switch your global Ruby to the fresh one: `asdf global ruby latest`.
 

--- a/ruby_on_rails/app_initialisation.md
+++ b/ruby_on_rails/app_initialisation.md
@@ -44,7 +44,8 @@ Some other adjustments must be performed manually.
 ### Automatic adjustments
 
 > ⭐The Gemfile reads the required ruby version from the `.ruby-version` file.
-> [This is used by Heroku and Deploio to determine what version to use.](https://devcenter.heroku.com/articles/ruby-versions)
+> [This is used by Heroku to determine what version to use.](https://devcenter.heroku.com/articles/ruby-versions)
+> Deploio reads the ruby version from the Gemfile, with the .ruby-version file inlined into it. https://paketo.io/docs/howto/ruby/#override-the-detected-ruby-version
 
 > ⭐️renuocop replaces the default rubocop-rails-omakase. We have our own set of rules at Renuo.
 > You can discuss them at https://github.com/renuo/renuocop and you can also contribute to them.


### PR DESCRIPTION
Added the link to ~~supported Heroku ruby versions, as Heroku build-packs will be the default (rather than paketo build-packs)~~ Paketo Ruby buildpack as this is still the default for Deploio. Also added a link to the Heroku ruby version.

https://devcenter.heroku.com/articles/ruby-support#ruby-versions

https://deploiocommunity.slack.com/archives/C05LUUQ3UPN/p1727258718131839

> I didn't link the automatic ruby version detection from the nine docs because [paketo buildpacks](https://docs.nine.ch/docs/deplo-io/languages/ruby) will be outdated once Heroku buildpacks become the next default.
> Regarding [Buildpacks](https://docs.nine.ch/de/docs/deplo-io/languages/ruby):
https://docs.nine.ch/de/docs/deplo-io/languages/ruby
This is not true, isn't it?
The question I want to have answered is the following: "What Ruby version is being supported by Deploio?" (edited) 
docs.nine.chdocs.nine.ch
[Ruby | Welcome to docs.nine.ch](https://docs.nine.ch/de/docs/deplo-io/languages/ruby)
Die Deploio-Build-Umgebung nutzt das [Paketo Ruby

> This is true but the number of ruby versions is just very limited. As you know, we have been testing the heroku-ruby buildpack and are evaluating if this should be the default. If it works well enough, Deploio will basically support any ruby version ever released.

