### PR TITLE
ruby-on-rails: Skip kamal by default when generating a new project

### DIFF
--- a/ruby_on_rails/app_initialisation.md
+++ b/ruby_on_rails/app_initialisation.md
@@ -15,7 +15,7 @@ You can do this with `gem update rails`. Beware of beta versions.
 
 * Start a new Rails project using
 ```
-rails new [project-name] --database=postgresql --skip-ci --no-skip-test --skip-action-mailbox --template https://raw.githubusercontent.com/renuo/applications-setup-guide/main/ruby_on_rails/template.rb
+rails new [project-name] --database=postgresql --skip-kamal --skip-ci --no-skip-test --skip-action-mailbox --template https://raw.githubusercontent.com/renuo/applications-setup-guide/main/ruby_on_rails/template.rb
 ```
 where the `project-name` is exactly the one you chose before.
 


### PR DESCRIPTION
Very likely we won't deploy using Kamal in almost all cases.