### PR TITLE
Adapt Ruby code snippets to new renuocop rules

### DIFF
--- a/ruby_on_rails/robots_txt.md
+++ b/ruby_on_rails/robots_txt.md
@@ -11,7 +11,7 @@ Add the following gem:
 
 ```ruby
 group :production do
-  gem 'norobots'
+  gem "norobots"
 end
 ```
 

--- a/ruby_on_rails/rspec.md
+++ b/ruby_on_rails/rspec.md
@@ -6,14 +6,14 @@ Add the following gems to your Gemfile:
 
 ```ruby
 group :development, :test do
-  gem 'factory_bot_rails'
-  gem 'rspec-rails'
+  gem "factory_bot_rails"
+  gem "rspec-rails"
 end
 
 group :test do
-  gem 'shoulda-matchers'
-  gem 'simplecov', require: false
-  gem 'super_diff'
+  gem "shoulda-matchers"
+  gem "simplecov", require: false
+  gem "super_diff"
 end
 ```
 
@@ -30,13 +30,13 @@ You should know exactly why you are adding each one of them and why is necessary
 
   ```ruby
   require 'simplecov'
-  SimpleCov.start 'rails' do
-    add_filter 'app/channels/application_cable/channel.rb'
-    add_filter 'app/channels/application_cable/connection.rb'
-    add_filter 'app/jobs/application_job.rb'
-    add_filter 'app/mailers/application_mailer.rb'
-    add_filter 'app/models/application_record.rb'
-    add_filter '.semaphore-cache'
+  SimpleCov.start "rails" do
+    add_filter "app/channels/application_cable/channel.rb"
+    add_filter "app/channels/application_cable/connection.rb"
+    add_filter "app/jobs/application_job.rb"
+    add_filter "app/mailers/application_mailer.rb"
+    add_filter "app/models/application_record.rb"
+    add_filter ".semaphore-cache"
     enable_coverage :branch
     minimum_coverage line: 100, branch: 100
   end

--- a/ruby_on_rails/sentry.md
+++ b/ruby_on_rails/sentry.md
@@ -22,9 +22,9 @@ to generate the commands for you.
 
   ```ruby
   group :production do
-    gem 'sentry-rails'
-    gem 'sentry-ruby'
-    gem 'sentry-sidekiq' # If the project uses Sidekiq for background jobs
+    gem "sentry-rails"
+    gem "sentry-ruby"
+    gem "sentry-sidekiq" # If the project uses Sidekiq for background jobs
   end
   ```
 


### PR DESCRIPTION
Can we run `rubocop` with `renuocop` rules on the application setup guide snippets somehow?