### PR TITLE
Do not start server on bin/setup

### DIFF
--- a/ruby_on_rails/template.rb
+++ b/ruby_on_rails/template.rb
@@ -19,6 +19,9 @@ insert_into_file "bin/setup", before: "\n  puts \"\\n== Preparing database ==\""
   RUBY
 end
 
+# remove the block unless ARGV.include?("--skip-server"). We don't want to start the server directly during setup.
+gsub_file "bin/setup", /\n{0,2}[ \t]*unless ARGV.include\?\("--skip-server"\).*?end/m, ""
+
 # add "ruby file: ".ruby-version" to the Gemfile under the line starting with "source"
 insert_into_file "Gemfile", after: /^source.*\n/ do
   <<~RUBY


### PR DESCRIPTION
`bin/setup` should simple setup the app not also start the server. The rest of the applications setup guide does not expect the server to be started.

See also https://github.com/rails/rails/commit/7ed09d3a387a780278700ac6edac3e97aa41aa3a