### PR TITLE
Recommend parallel_tests

### DIFF
--- a/ruby_on_rails/app_initialisation.md
+++ b/ruby_on_rails/app_initialisation.md
@@ -15,7 +15,7 @@ You can do this with `gem update rails`. Beware of beta versions.
 
 * Start a new Rails project using
 ```
-rails new [project-name] --database=postgresql --skip-kamal --skip-ci --no-skip-test --skip-action-mailbox --template https://raw.githubusercontent.com/renuo/applications-setup-guide/main/ruby_on_rails/template.rb
+rails new [project-name] --database=postgresql --skip-kamal --skip-ci --skip-action-mailbox --template https://raw.githubusercontent.com/renuo/applications-setup-guide/main/ruby_on_rails/template.rb
 ```
 where the `project-name` is exactly the one you chose before.
 
@@ -128,7 +128,6 @@ Check existing projects for an example of the usage.
   config.i18n.raise_on_missing_translations = true # uncomment
 
   config.generators do |g|
-    g.test_framework :rspec
     g.apply_rubocop_autocorrect_after_generate!
   end
   ```

--- a/ruby_on_rails/rspec.md
+++ b/ruby_on_rails/rspec.md
@@ -1,6 +1,6 @@
 # Setup RSpec
 
-Even though Rails uses Minitest per default, RSpec is the *de-facto* standard at Renuo. We love RSpec and we strongly suggest to use it.
+Even though Rails uses Minitest per default, RSpec is the *de-facto* standard at Renuo.
 
 Add the following gems to your Gemfile:
 
@@ -8,6 +8,7 @@ Add the following gems to your Gemfile:
 group :development, :test do
   gem "factory_bot_rails"
   gem "rspec-rails"
+  gem "parallel_tests"
 end
 
 group :test do
@@ -61,51 +62,63 @@ You should know exactly why you are adding each one of them and why is necessary
   Please check the [spec_helper template](../templates/spec/spec_helper.rb)
 
 * Add the configurations:
-  ```rb
-  # spec/rails_helper.rb:
 
-    # after `require 'rspec/rails'`
-    require 'capybara/rspec'
-    require 'capybara/rails'
-    require 'selenium/webdriver'
-    require 'super_diff/rspec-rails'
+```rb
+# spec/rails_helper.rb:
 
-    Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+# after `require 'rspec/rails'`
+require 'capybara/rspec'
+require 'capybara/rails'
+require 'selenium/webdriver'
+require 'super_diff/rspec-rails'
 
-    # ... (omitted configs here)
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
-    RSpec.configure do |config|
-      # ... (omitted configs here)
+# ... (omitted configs here)
 
-      config.before do |example|
-        ActionMailer::Base.deliveries.clear
-        I18n.locale = I18n.default_locale
-        Rails.logger.debug { "--- #{example.location} ---" }
-      end
+RSpec.configure do |config|
+  # ... (omitted configs here)
 
-      config.after do |example|
-        Rails.logger.debug { "--- #{example.location} FINISHED ---" }
-      end
+  config.before do |example|
+    ActionMailer::Base.deliveries.clear
+    I18n.locale = I18n.default_locale
+    Rails.logger.debug { "--- #{example.location} ---" }
+  end
 
-      config.before(:each, type: :system) do
-        driven_by :rack_test
-      end
+  config.after do |example|
+    Rails.logger.debug { "--- #{example.location} FINISHED ---" }
+  end
 
-      config.before(:each, type: :system, js: true) do
-        driven_by ENV['SELENIUM_DRIVER']&.to_sym || :selenium_chrome_headless
-        Capybara.page.current_window.resize_to(1280, 800)
-      end
-    end
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
 
-  # config/application.example.yml
-  test:
-    # SELENIUM_DRIVER: 'selenium_chrome'
-    SELENIUM_DRIVER: 'selenium_chrome_headless'
-  ```
+  config.before(:each, type: :system, js: true) do
+    driven_by ENV['SELENIUM_DRIVER']&.to_sym || :selenium_chrome_headless
+    Capybara.page.current_window.resize_to(1280, 800)
+  end
+end
+```
+
+```yml
+# config/application.example.yml
+test:
+  # SELENIUM_DRIVER: 'selenium_chrome'
+  SELENIUM_DRIVER: 'selenium_chrome_headless'
+```
+
+```rb
+# config/environments/development.rb
+
+config.generators do |g|
+  g.test_framework :rspec
+end
+
+```
 
 Please check the full [rails_helper template](../templates/spec/rails_helper.rb) to compare.
 
-* Add the line `bundle exec rspec` to `bin/check`
+* Add the line `bundle exec parallel_rspec` to `bin/check`
 
 > **Note**: If you want to debug a spec, you can simply uncomment the line `SELENIUM_DRIVER` in the application.yml to not run it headless:
 


### PR DESCRIPTION
parallel_tests allows us to make use of all our processors instead of a single one. It's definitely time to have it by default.

What's next:
* [ ] make rspec optional (or opt-in) and suggest a possible experimentation of minitest
* [ ] suggest splitting of system tests from everything else from the beginning