### PR TITLE
Remove secret_key_base.rb initializer

### DIFF
--- a/templates/config/initializers/secret_key_base.rb
+++ b/templates/config/initializers/secret_key_base.rb
@@ -1,1 +1,0 @@
-Rails.application.config.secret_key_base = ENV['SECRET_KEY_BASE']


### PR DESCRIPTION
Rails uses the env variable by default. See
https://blog.saeloun.com/2023/08/11/rails-7-1-store-secret-key-base-in-rails-config/