### PR TITLE
Update branch protection rules

### DIFF
--- a/configure_git_repository.md
+++ b/configure_git_repository.md
@@ -16,12 +16,9 @@ Please stick to it unless you have special needs.
 * Branches
   * Default branch: either `main` or `develop` depending on whether you want one or two environments.
 * Rules/Rulesets
-  * We use two rulesets: one for `main` and one for everything else. This ensures that long-lived branches like `redesign` and feature branches like `feat/my-feature` share the same protection rules as `develop`.
-  * `non-main`
+  * `develop`
     * Enforcement status: `Active`
-    * Branch targeting criteria:
-      * Include all branches
-      * Exclude by pattern: `main`
+    * Branch targeting criteria: `develop`
     * Bypass list: add `Repository Admin` Role with *allow for pull requests only* option
     * Restrict deletions
     * Require linear history
@@ -29,10 +26,11 @@ Please stick to it unless you have special needs.
     * Require status checks to pass
       * Select `ci/semaphore/push`
     * Block force pushes
-  * `main` (same as non-main but...)
+  * `main` (same as develop but...)
     * Branch targeting criteria: `main`
     * ❌ Require a pull request before merging
     * ❌ Require status checks to pass
+
 * Autolink references
   * Add a new Autolink reference with:
     * Reference prefix: `TICKET-`

--- a/configure_git_repository.md
+++ b/configure_git_repository.md
@@ -36,6 +36,9 @@ Please stick to it unless you have special needs.
     * Reference prefix: `TICKET-`
     * Target URL: `https://redmine.renuo.ch/issues/<num>`
 
+In case you have a second long-living environment (e.g., for a design rewrite, a new major version, etc.),
+consider applying the same rules as on `develop` to it as well.
+
 ## Team
 
 Each project has a team owning it. The team is named after the project: `[team-name] = [project-name]`.


### PR DESCRIPTION
The branch protection rules were updated in #437 (without any apparent discussion, which I find odd given the impact and high problematics of the change). The change applies the *exact same* restrictive rules to all branches, no matter their role in the development process.

This yields the following issues:
- Depfu cannot update dependencies anymore as Depfu receives a 422 - Reference does not exist error when trying to push its stuff.
- You're not allowed to force push onto your feature branches, which is a common practice to keep the history clean and avoid accidental pushs of e.g., "fixup!", "wip", etc. commits.
- You need a linear history in your working feature branches, so you're not allowed to merge anything. This just unnecessarily complicates the process and does not bring any value since we will squash the feature branch anyway into a single commit so why bother with a linear history in the feature branch?
- If your feature branch depends on another feature branch (which happens a lot in practice), you're not allowed to rebase and force push anymore, you'd have to merge in the other feature branch (which is not even allowed either), so basically you're stuck.
- You cannot revert pull requests anymore

One project recently was setup according to the ASG including this change and we quickly ran into issues so I had to exclude the feature branches from the protection rules. The suggested changes in this PR now reflect what we have there. One possible alternative setup which might work would be:

Three protection rules:
- `main`, as it is right now
- `develop` and long living branches (i.e., anything that does not match `*/**`, so like `redesign`, `develop2`, etc.), with the same rules as the current `non-main` rule
- `Feature` branches, matching `*/**`, with the only rule that CI has to pass before merging, so that you don't merge failing code into another feature branch.
  - Even though this reflects the original intent of the change in #437, I don't think that this is even a good idea. Why shouldn't I be allowed to split my feature into multiple separate branches that logically make sense and are easier to review but only the last PR in the stack is actually passing? I think, this is within the responsibility of the developer to make sure that his work is tidy and logical so I wouldn't restrict this when it's still a WIP.
