### PR TITLE
Replace emoji shortcodes with unicode emoji and drop emojify step

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,12 +15,6 @@ jobs:
         uses: peaceiris/actions-mdbook@v2
         with:
           mdbook-version: 'latest'
-      - name: Emojify Book
-        run: |
-          set -x
-          wget --no-verbose https://github.com/shonfeder/emojitsu/releases/download/0.1.1/gh-actions-emojitsu
-          chmod +x gh-actions-emojitsu
-          find . -type f -name "*.md" -exec ./gh-actions-emojitsu emojify -i {} \;
       - run: mdbook build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -26,10 +26,4 @@ jobs:
         uses: peaceiris/actions-mdbook@v2
         with:
           mdbook-version: 'latest'
-      - name: Emojify Book
-        run: |
-          set -x
-          wget --no-verbose https://github.com/shonfeder/emojitsu/releases/download/0.1.1/gh-actions-emojitsu
-          chmod +x gh-actions-emojitsu
-          find . -type f -name "*.md" -exec ./gh-actions-emojitsu emojify -i {} \;
       - run: mdbook build

--- a/ruby_on_rails/devise.md
+++ b/ruby_on_rails/devise.md
@@ -25,4 +25,4 @@ DEVISE_SECRET_KEY="rake secret"
 DEVISE_PEPPER="rake secret"
 ```
 
-Open a pull request! :tada:
+Open a pull request! 🎉

--- a/ruby_on_rails/hotjar.md
+++ b/ruby_on_rails/hotjar.md
@@ -1,4 +1,4 @@
-# :fire: Hotjar
+# 🔥 Hotjar
 
 * Add a new site on the Hotjar dashboard using the Renuo Hotjar account
 (credentials are in Passwork). Note the site ID of the generated site.

--- a/ruby_on_rails/linting_and_automatic_check.md
+++ b/ruby_on_rails/linting_and_automatic_check.md
@@ -1,11 +1,11 @@
-# Linting and automatic checks :white_check_mark:
+# Linting and automatic checks ✅
 
 All Renuo projects contain (and your project must contain as well) the following linters.
 Every linter consists of a gem (usually) and a command to add to our `bin/fastcheck` script.
 
 Check out the `bin/fastcheck` [fastcheck](../templates/bin/fastcheck) for the final version of it.
 
-## Renuocop :cop:
+## Renuocop 👮
 
 > ✨ Installed by the Renuo Rails template (replaces `rubocop-rails-omakase`).
 
@@ -171,4 +171,4 @@ The templates folder contains a template for the eslint configuration.
 
 ## All Good!
 
-Now your `bin/fastcheck` is not that fast anymore :smile:
+Now your `bin/fastcheck` is not that fast anymore 😄

--- a/ruby_on_rails/rspec.md
+++ b/ruby_on_rails/rspec.md
@@ -165,15 +165,15 @@ end
 
 ![CleanShot 2021-06-25 at 16 54 22](https://user-images.githubusercontent.com/1319150/123443347-1bbcae80-d5d6-11eb-8ba5-0d2c9ae4a37c.gif)
 
-## :white_check_mark: Our first (green) test
+## ✅ Our first (green) test
 
 We are now going to write a first test to ensure that the whole configuration is working:
 
-* `bin/check` should be green :white_check_mark:
+* `bin/check` should be green ✅
 * Write the test [`spec/system/health_spec.rb`](../templates/spec/system/health_spec.rb)
 * Run `bin/check` and the test should pass and coverage is 100%.
 
-Commit and push your changes! :tada:
+Commit and push your changes! 🎉
 
 > [!NOTE]
 > The default health check path for Rails is `/up`. [Learn more in the Rails guides](https://edgeapi.rubyonrails.org/classes/Rails/HealthController.html).

--- a/ruby_on_rails/send_emails.md
+++ b/ruby_on_rails/send_emails.md
@@ -1,4 +1,4 @@
-# :mailbox: Send Emails
+# 📬 Send Emails
 
 As soon as you have to send emails please follow those suggestions.
 They will help you having a proper system to deliver emails and development environment.


### PR DESCRIPTION
The mdbook deploy and lint workflows previously ran shonfeder/emojitsu to expand GitHub-style :shortcode: emoji into unicode at build time. Replace the shortcodes with unicode directly in the source so the build step is no longer needed, and drop the Emojify Book steps from both workflows.